### PR TITLE
Upgrade generated dashboard access tokens

### DIFF
--- a/vizzly/auth.py
+++ b/vizzly/auth.py
@@ -9,14 +9,18 @@ def sign(payload, expiry_ttl_in_minutes, private_key, timezone):
   payload["expires"] = (now + timedelta(expiry_ttl_in_minutes)).isoformat()
   return jwt.encode(payload, private_key, algorithm='ES256')
 
-def sign_dashboard_access_token(expiry_ttl_in_minutes, access_type, organisation_id, dashboard_id, user_reference, scope, private_key, timezone=tz.tzlocal()):
-  return sign({
-  "accessType": access_type,
-  "organisationId": organisation_id,
-  "dashboardId": dashboard_id,
-  "userReference": user_reference,
-  "scope": scope
-}, expiry_ttl_in_minutes, private_key, timezone)
+def sign_dashboard_access_token(expiry_ttl_in_minutes, project_id, user_reference, private_key, scope='read_write', access_type='standard', parent_dashboard_ids=None, timezone=tz.tzlocal()):
+  params = {
+    "accessType": access_type,
+    "projectId": project_id,
+    "userReference": user_reference,
+    "scope": scope
+  }
+
+  if parent_dashboard_ids is not None:
+    params['parentDashboardIds'] = parent_dashboard_ids
+
+  return sign(params, expiry_ttl_in_minutes, private_key, timezone)
 
 def sign_data_access_token(expiry_ttl_in_minutes, data_set_ids, secure_filters, private_key, timezone=tz.tzlocal()):
   return sign({


### PR DESCRIPTION
- Replaces deprecated `dashboardId` value with "parentDashboardIds"
- Adds defaults for `access_type` and `scope`
- Replaces `organisation_id` with the `project_id` as we now support multiple projects per organisation